### PR TITLE
Rebrand to brigitjacoby.com with SEO-first redesign

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/home",
+        destination: "/",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,108 +1,186 @@
-"use client";
-
+import type { Metadata } from "next";
+import Link from "next/link";
 import Image from "next/image";
-import Navbar from "../components/Navbar";
-import Footer from "../components/Footer";
 
-// Break down the about GGT text into smaller sections for better readability
-const aboutGGTIntro = `Golden Gate Therapy was established in April 2024 to provide high-quality psychotherapy services to children and their families.`;
-const aboutGGTMission = `Founder of Golden Gate Therapy, Brigit Jacoby, aims to work diligently with your family’s particular needs.`;
-const aboutGGTImportance = `Educators such as Teachers, Tutors, and Therapists are some of the first non-family members to interact with your child. In early stages of life, safety, belonging, and confidence are beginning to form in the child’s brain.`;
-const aboutGGTRelationships = `Interpersonal relationships, both family and non-family, are crucial for early development, including social skills such as trust, respect, and boundaries.`;
-const aboutGGTImpact = `For young people, every relationship is significant and important. This is where Golden Gate Therapy enters.`;
+export const metadata: Metadata = {
+  title: "About Brigit Jacoby, LCSW | Therapist for High Achievers",
+  description:
+    "Meet Brigit Jacoby, LCSW — a Licensed Clinical Social Worker in Venice Beach specializing in anxiety and people-pleasing therapy for high-achieving adults throughout California.",
+};
 
-// Break down the about Brigit text into smaller sections for better readability
-const aboutBrigitIntro = `Brigit Jacoby is a Licensed Clinical Social Worker living and working in the San Francisco Bay Area.`;
-const aboutBrigitEducation = `Brigit received her Masters of Social Work from the University of Southern California and graduated from the University of California, Irvine, with a B.A. in Psychology and Social Behavior.`;
-const aboutBrigitExperience = `While obtaining her undergraduate and graduate degrees, Brigit spent a lot of her time working with children as young as 2.5 years old to young adults in their 20s and their families, which inspired the creation of Golden Gate Therapy.`;
-const aboutBrigitPersonal = `In her personal time, Brigit enjoys spending time with her dog Marshall by walking to parks and exploring San Francisco with her husband.`;
+const issues = [
+  "Anxiety and high-functioning stress",
+  "People-pleasing and difficulty setting boundaries",
+  "Finding and using your authentic voice",
+  "Building deeper, more honest relationships",
+  "Perfectionism and fear of failure or judgment",
+  "Burnout and the loss of identity beyond achievement",
+];
+
+const credentials = [
+  "Licensed Clinical Social Worker (LCSW #121726) — California",
+  "Master of Social Work (MSW) — University of Southern California",
+  "B.A. in Psychology and Social Behavior — UC Irvine",
+  "Specialized training in anxiety, attachment, and relational therapy",
+  "Currently accepting new clients for virtual sessions throughout California",
+];
 
 export default function About() {
   return (
-    <>
-      <Navbar />
-      <div
-        className="bg-gray-100"
-        style={{
-          minHeight: "85vh",
-          background: "linear-gradient(to bottom, #E6E6E6, #F5F5F5)",
-        }}
-      >
-        <div className="container mx-auto py-16 px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h1 className="text-3xl sm:text-4xl font-bold text-gray-800 mb-6">
-              About Golden Gate Therapy
-            </h1>
-          </div>
-
-          {/* First Section: Logo and About GGT Text Side by Side */}
-          <div className="flex flex-col lg:flex-row items-center justify-between mb-16 gap-8">
-            {/* Image Section */}
-            <div className="relative w-full lg:w-1/2 h-auto max-w-md md:max-w-lg mb-8 lg:mb-0">
-              <Image
-                src="/logo.png"
-                alt="About Logo"
-                layout="intrinsic"
-                width={600} // Adjust width as needed
-                height={600} // Adjust height as needed
-              />
+    <main>
+      {/* Page hero */}
+      <section className="bg-warm-cream py-20 lg:py-28">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
+            <div>
+              <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-6">
+                About Brigit
+              </p>
+              <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-6">
+                You don&apos;t have to perform here.
+              </h1>
+              <p className="text-base sm:text-lg text-stone-gray leading-relaxed mb-4">
+                That&apos;s the first thing I want you to know. Whatever version
+                of yourself you bring to our sessions — the put-together one,
+                the exhausted one, the one who doesn&apos;t have the right words
+                yet — is exactly the right one.
+              </p>
+              <p className="text-base sm:text-lg text-stone-gray leading-relaxed">
+                I became a therapist because I believe that the most meaningful
+                thing a person can do is learn to be honest — with themselves,
+                and with the people they love.
+              </p>
             </div>
-            {/* Text Section */}
-            <div className="w-full lg:w-1/2">
-              <div className="bg-white p-6 rounded-lg shadow-md h-full">
-                <p className="text-lg sm:text-xl text-gray-700 leading-relaxed mb-4">
-                  {aboutGGTIntro}
-                </p>
-                <p className="text-lg sm:text-xl text-gray-700 leading-relaxed mb-4">
-                  {aboutGGTMission}
-                </p>
-                <p className="text-lg sm:text-xl text-gray-700 leading-relaxed mb-4">
-                  {aboutGGTImportance}
-                </p>
-                <p className="text-lg sm:text-xl text-gray-700 leading-relaxed mb-4">
-                  {aboutGGTRelationships}
-                </p>
-                <p className="text-lg sm:text-xl text-gray-700 leading-relaxed mb-8">
-                  {aboutGGTImpact}
-                </p>
+            <div className="relative flex justify-center lg:justify-end">
+              <div className="relative w-full max-w-md">
+                <div className="absolute -inset-4 bg-soft-sage rounded-3xl rotate-2" />
+                <Image
+                  src="/brigit.png"
+                  alt="Brigit Jacoby, LCSW — Licensed Clinical Social Worker in Venice Beach"
+                  width={500}
+                  height={600}
+                  className="relative rounded-2xl shadow-xl object-cover w-full"
+                  priority
+                />
               </div>
             </div>
           </div>
+        </div>
+      </section>
 
-          {/* Second Section: Brigit Image and About Brigit Text Side by Side */}
-          <div className="flex flex-col lg:flex-row items-center justify-between mb-16 gap-8">
-            {/* Image Section */}
-            <div className="relative w-full lg:w-1/2 h-auto max-w-md md:max-w-lg mb-8 lg:mb-0">
-              <Image
-                src="/brigit.png"
-                alt="Brigit Jacoby"
-                layout="intrinsic"
-                width={600} // Adjust width as needed
-                height={600} // Adjust height as needed
-                className="rounded-lg shadow-lg"
-              />
+      {/* Who I work with */}
+      <section className="bg-white py-16 lg:py-20">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid lg:grid-cols-2 gap-12 items-start">
+            <div>
+              <h2 className="text-3xl sm:text-4xl font-bold italic text-charcoal mb-6">
+                Who I work with
+              </h2>
+              <p className="text-stone-gray leading-relaxed mb-4">
+                I specialize in working with high-achieving adults —
+                professionals, creatives, entrepreneurs, and anyone who has
+                mastered the art of seeming fine. My clients are smart,
+                self-aware, and often their own harshest critics.
+              </p>
+              <p className="text-stone-gray leading-relaxed mb-8">
+                They come to therapy not because they&apos;re falling apart, but
+                because something quieter is happening: a growing disconnection
+                between who they are and how they&apos;re living.
+              </p>
+              <h3 className="text-sm font-semibold uppercase tracking-widest text-charcoal mb-4">
+                Issues I most often work with:
+              </h3>
+              <ul className="space-y-3">
+                {issues.map((issue) => (
+                  <li key={issue} className="flex items-start gap-3">
+                    <span className="mt-1.5 flex-shrink-0 w-2 h-2 rounded-full bg-sage-teal" />
+                    <span className="text-stone-gray text-sm leading-relaxed">
+                      {issue}
+                    </span>
+                  </li>
+                ))}
+              </ul>
             </div>
-            {/* Text Section */}
-            <div className="w-full lg:w-1/2">
-              <div className="bg-white p-6 rounded-lg shadow-md h-full">
-                <p className="text-lg sm:text-xl text-gray-700 leading-relaxed mb-4">
-                  {aboutBrigitIntro}
+
+            <div>
+              <div className="bg-soft-sage rounded-2xl p-8">
+                <h2 className="text-2xl font-bold italic text-charcoal mb-5">
+                  My approach
+                </h2>
+                <p className="text-charcoal/80 leading-relaxed mb-4">
+                  I draw from a range of evidence-based modalities — including
+                  Cognitive Behavioral Therapy (CBT), Acceptance and Commitment
+                  Therapy (ACT), and attachment-based approaches — but what I
+                  care about most is creating a relationship with you that feels
+                  real.
                 </p>
-                <p className="text-lg sm:text-xl text-gray-700 leading-relaxed mb-4">
-                  {aboutBrigitEducation}
+                <p className="text-charcoal/80 leading-relaxed mb-4">
+                  Therapy works when you feel safe enough to be honest, so
+                  that&apos;s always where we start.
                 </p>
-                <p className="text-lg sm:text-xl text-gray-700 leading-relaxed mb-4">
-                  {aboutBrigitExperience}
-                </p>
-                <p className="text-lg sm:text-xl text-gray-700 leading-relaxed mb-8">
-                  {aboutBrigitPersonal}
+                <p className="text-charcoal/80 leading-relaxed">
+                  Sessions are virtual, which means you can show up from
+                  wherever you&apos;re most comfortable — your home, your
+                  office, your car in a parking lot between meetings. No
+                  commute. No waiting room. Just space for you.
                 </p>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <Footer />
-    </>
+      </section>
+
+      {/* Credentials */}
+      <section className="bg-warm-cream py-16 lg:py-20">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-bold italic text-charcoal mb-8 text-center">
+            Credentials
+          </h2>
+          <div className="bg-white rounded-2xl p-8 shadow-sm">
+            <ul className="space-y-4">
+              {credentials.map((cred) => (
+                <li key={cred} className="flex items-start gap-4">
+                  <span className="mt-1 flex-shrink-0 w-5 h-5 rounded-full bg-soft-sage flex items-center justify-center">
+                    <svg
+                      className="w-3 h-3 text-sage-teal"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={3}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  </span>
+                  <span className="text-charcoal text-sm leading-relaxed">
+                    {cred}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="bg-deep-teal py-20">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-3xl sm:text-4xl font-bold italic text-white mb-5">
+            I&apos;d love to connect.
+          </h2>
+          <p className="text-white/80 text-lg leading-relaxed mb-8">
+            If anything on this page resonated with you, that&apos;s usually a
+            sign worth listening to. Reach out — there&apos;s no pressure, no
+            commitment.
+          </p>
+          <Link href="/contact" className="btn-white">
+            Schedule a Free Consultation →
+          </Link>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,33 +1,86 @@
+import Link from "next/link";
+
 export default function Footer() {
   return (
-    <footer className="bg-gray-800 p-6 text-white">
-      <div className="flex flex-col items-center space-y-4 md:space-y-0 md:flex-row md:justify-between">
-        {/* Psychology Today Badge */}
-        <div
-          className="flex items-center justify-center"
-          style={{ height: "50px" }}
-        >
-          {/* We reserve space for the badge */}
-          <a
-            href="https://www.psychologytoday.com/profile/1352154"
-            className="sx-verified-seal"
-            aria-label="Psychology Today Verified"
-          />
-          <script
-            type="text/javascript"
-            src="https://member.psychologytoday.com/verified-seal.js"
-            data-badge="14"
-            data-id="1352154"
-            data-code="aHR0cHM6Ly93d3cucHN5Y2hvbG9neXRvZGF5LmNvbS9hcGkvdmVyaWZpZWQtc2VhbC9zZWFscy8xNC9wcm9maWxlLzEzNTIxNTQ/Y2FsbGJhY2s9c3hjYWxsYmFjaw=="
-            defer
-          />
+    <footer className="bg-charcoal text-white">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="grid md:grid-cols-3 gap-10">
+          {/* Brand */}
+          <div>
+            <p className="font-semibold text-lg mb-1">Brigit Jacoby, LCSW</p>
+            <p className="text-stone-gray text-sm mb-4">
+              Licensed Clinical Social Worker #121726
+            </p>
+            <p className="text-stone-gray text-sm leading-relaxed">
+              Virtual therapy for high-achieving adults throughout California.
+            </p>
+          </div>
+
+          {/* Nav */}
+          <div>
+            <p className="text-xs uppercase tracking-widest text-stone-gray mb-4">
+              Navigation
+            </p>
+            <ul className="space-y-2">
+              {[
+                { href: "/", label: "Home" },
+                { href: "/about", label: "About" },
+                { href: "/services", label: "Services" },
+                { href: "/contact", label: "Contact" },
+              ].map(({ href, label }) => (
+                <li key={href}>
+                  <Link
+                    href={href}
+                    className="text-sm text-stone-gray hover:text-white transition-colors"
+                  >
+                    {label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Contact + PT badge */}
+          <div>
+            <p className="text-xs uppercase tracking-widest text-stone-gray mb-4">
+              Get in Touch
+            </p>
+            <p className="text-sm text-stone-gray mb-1">
+              <a
+                href="mailto:brigit@goldengatetherapy.com"
+                className="hover:text-white transition-colors"
+              >
+                brigit@goldengatetherapy.com
+              </a>
+            </p>
+            <p className="text-sm text-stone-gray mb-6">
+              <a href="tel:4154390499" className="hover:text-white transition-colors">
+                (415) 439-0499
+              </a>
+            </p>
+            <a
+              href="https://www.psychologytoday.com/profile/1352154"
+              className="sx-verified-seal"
+              aria-label="Psychology Today Verified"
+            />
+            <script
+              type="text/javascript"
+              src="https://member.psychologytoday.com/verified-seal.js"
+              data-badge="14"
+              data-id="1352154"
+              data-code="aHR0cHM6Ly93d3cucHN5Y2hvbG9neXRvZGF5LmNvbS9hcGkvdmVyaWZpZWQtc2VhbC9zZWFscy8xNC9wcm9maWxlLzEzNTIxNTQ/Y2FsbGJhY2s9c3hjYWxsYmFjaw=="
+              defer
+            />
+          </div>
         </div>
 
-        {/* Copyright Text */}
-        <p className="text-center md:text-left">
-          &copy; {new Date().getFullYear()} Golden Gate Therapy. All rights
-          reserved.
-        </p>
+        <div className="border-t border-white/10 mt-10 pt-6 flex flex-col sm:flex-row justify-between items-center gap-4 text-xs text-stone-gray">
+          <p>
+            &copy; {new Date().getFullYear()} Brigit Jacoby, LCSW. All rights
+            reserved.
+          </p>
+          <p>Venice Beach, CA · Virtual throughout California</p>
+        </div>
       </div>
     </footer>
   );

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -54,8 +54,8 @@ export default function Footer() {
               </a>
             </p>
             <p className="text-sm text-stone-gray mb-6">
-              <a href="tel:4154390499" className="hover:text-white transition-colors">
-                (415) 439-0499
+              <a href="tel:3105611461" className="hover:text-white transition-colors">
+                (310) 561-1461
               </a>
             </p>
             <a

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -1,108 +1,92 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 
-type Path = "/" | "/about" | "/services" | "/contact";
+const links = [
+  { href: "/about", label: "About" },
+  { href: "/services", label: "Services" },
+  { href: "/contact", label: "Contact" },
+];
 
 export default function Navbar() {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-  const toggleMenu = () => {
-    setIsMenuOpen(!isMenuOpen);
-  };
-
-  const navigateTo = (path: Path) => {
-    window.location.href = path;
-  };
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
 
   return (
-    <nav
-      className="bg-gradient-to-r from-orange-500 to-red-500 p-4 shadow-lg sticky top-0 z-50"
-      style={{ background: "linear-gradient(to right, #FB6E4A, #E63946)" }}
-    >
-      <div className="container mx-auto flex justify-between items-center">
-        {/* Logo */}
-        <button
-          onClick={() => navigateTo("/")}
-          className="text-white text-lg font-bold"
-        >
-          Golden Gate Therapy
-        </button>
-        {/* Hamburger Menu Button */}
-        <button
-          className="text-white lg:hidden focus:outline-none"
-          onClick={toggleMenu}
-        >
-          <svg
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M4 6h16M4 12h16M4 18h16"
-            ></path>
-          </svg>
-        </button>
-        {/* Links for larger screens */}
-        <div className="hidden lg:flex space-x-4">
+    <nav className="bg-white border-b border-gray-100 sticky top-0 z-50">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          {/* Logo */}
+          <Link href="/" className="flex flex-col leading-tight">
+            <span className="font-semibold text-charcoal text-base tracking-tight">
+              Brigit Jacoby
+            </span>
+            <span className="text-xs text-stone-gray tracking-widest uppercase">
+              LCSW · Therapist
+            </span>
+          </Link>
+
+          {/* Desktop nav */}
+          <div className="hidden md:flex items-center gap-8">
+            {links.map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className={`text-sm font-medium transition-colors duration-150 ${
+                  pathname === href
+                    ? "text-sage-teal"
+                    : "text-stone-gray hover:text-charcoal"
+                }`}
+              >
+                {label}
+              </Link>
+            ))}
+            <Link href="/contact" className="btn-primary">
+              Book a Free Consultation
+            </Link>
+          </div>
+
+          {/* Mobile hamburger */}
           <button
-            onClick={() => navigateTo("/")}
-            className="text-white hover:text-gray-200"
+            className="md:hidden p-2 text-charcoal"
+            onClick={() => setIsOpen(!isOpen)}
+            aria-label="Toggle menu"
           >
-            Home
-          </button>
-          <button
-            onClick={() => navigateTo("/about")}
-            className="text-white font-medium hover:text-yellow-100"
-          >
-            About
-          </button>
-          <button
-            onClick={() => navigateTo("/services")}
-            className="text-white font-medium hover:text-yellow-100"
-          >
-            Services
-          </button>
-          <button
-            onClick={() => navigateTo("/contact")}
-            className="text-white font-medium hover:text-yellow-100"
-          >
-            Contact
+            {isOpen ? (
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            ) : (
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            )}
           </button>
         </div>
       </div>
-      {/* Dropdown menu for smaller screens */}
-      {isMenuOpen && (
-        <div className="lg:hidden mt-2 space-y-2">
-          <button
-            onClick={() => navigateTo("/")}
-            className="block text-white hover:text-gray-200"
+
+      {/* Mobile menu */}
+      {isOpen && (
+        <div className="md:hidden bg-white border-t border-gray-100 px-4 py-4 space-y-3">
+          {links.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              className="block text-sm font-medium text-charcoal py-2"
+              onClick={() => setIsOpen(false)}
+            >
+              {label}
+            </Link>
+          ))}
+          <Link
+            href="/contact"
+            className="btn-primary block text-center mt-4"
+            onClick={() => setIsOpen(false)}
           >
-            Home
-          </button>
-          <button
-            onClick={() => navigateTo("/about")}
-            className="block text-white hover:text-gray-200"
-          >
-            About
-          </button>
-          <button
-            onClick={() => navigateTo("/services")}
-            className="block text-white hover:text-gray-200"
-          >
-            Services
-          </button>
-          <button
-            onClick={() => navigateTo("/contact")}
-            className="block text-white hover:text-gray-200"
-          >
-            Contact
-          </button>
+            Book a Free Consultation
+          </Link>
         </div>
       )}
     </nav>

--- a/src/app/contact/ContactForm.tsx
+++ b/src/app/contact/ContactForm.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import React, { useState, ChangeEvent, FormEvent } from "react";
+import emailjs from "emailjs-com";
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+
+interface FormData {
+  first_name: string;
+  last_name: string;
+  email: string;
+  message: string;
+}
+
+const faqs = [
+  {
+    q: "What's the difference between therapy and coaching?",
+    a: "Therapy goes deeper — we explore the roots of patterns, not just the surface behaviors. As a Licensed Clinical Social Worker, I'm trained to work with mental health concerns and the emotional experiences that drive them.",
+  },
+  {
+    q: "Do you take insurance?",
+    a: "I'm an out-of-network provider, which means I don't bill insurance directly. However, I can provide a superbill that you can submit to your insurance company for potential reimbursement if you have out-of-network benefits.",
+  },
+  {
+    q: "How long will I be in therapy?",
+    a: "That depends entirely on you and your goals. Some people come for a focused period of a few months; others find value in longer-term work. We'll check in regularly to make sure therapy is serving you.",
+  },
+  {
+    q: "What if I'm not sure therapy is right for me?",
+    a: "That's exactly what the free consultation is for. You don't need to know if you're \"ready.\" You just need to show up.",
+  },
+];
+
+export default function ContactForm() {
+  const [formData, setFormData] = useState<FormData>({
+    first_name: "",
+    last_name: "",
+    email: "",
+    message: "",
+  });
+
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    if (!formData.first_name || !formData.last_name || !formData.email || !formData.message) {
+      toast.error("Please fill out all fields.");
+      return;
+    }
+
+    try {
+      const result = await emailjs.send(
+        "service_tldiyls",
+        "template_qzfrvvp",
+        { ...formData },
+        "ESJuALi_woGqpuAJe",
+      );
+
+      if (result.text === "OK") {
+        toast.success("Message sent! I'll be in touch within 1–2 business days.");
+        setFormData({ first_name: "", last_name: "", email: "", message: "" });
+      } else {
+        toast.error("Message not sent. Please try again.");
+      }
+    } catch {
+      toast.error("Failed to send. Please try again or email directly.");
+    }
+  };
+
+  return (
+    <>
+      <ToastContainer position="top-center" />
+
+      {/* Form + contact info */}
+      <section className="bg-white py-16 lg:py-20">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid lg:grid-cols-2 gap-12">
+            {/* Left — info */}
+            <div>
+              <h2 className="text-2xl font-bold italic text-charcoal mb-5">
+                Prefer to reach out first?
+              </h2>
+              <p className="text-stone-gray leading-relaxed mb-6">
+                That&apos;s completely fine. Send a message below and I&apos;ll
+                get back to you within 1–2 business days.
+              </p>
+              <div className="space-y-3 mb-8">
+                <p className="text-sm text-charcoal">
+                  <span className="font-medium">Email:</span>{" "}
+                  <a
+                    href="mailto:brigit@goldengatetherapy.com"
+                    className="text-sage-teal hover:underline"
+                  >
+                    brigit@goldengatetherapy.com
+                  </a>
+                </p>
+                <p className="text-sm text-charcoal">
+                  <span className="font-medium">Phone:</span>{" "}
+                  <a
+                    href="tel:4154390499"
+                    className="text-sage-teal hover:underline"
+                  >
+                    (415) 439-0499
+                  </a>
+                </p>
+                <p className="text-sm text-charcoal">
+                  <span className="font-medium">Location:</span> Venice Beach,
+                  CA · Virtual throughout California
+                </p>
+              </div>
+
+              {/* Crisis notice */}
+              <div className="bg-warm-cream rounded-xl p-4 border border-sage-teal/20">
+                <p className="text-xs text-stone-gray leading-relaxed">
+                  <span className="font-semibold text-charcoal">
+                    If you are in crisis:
+                  </span>{" "}
+                  Please contact the{" "}
+                  <span className="font-semibold">
+                    988 Suicide &amp; Crisis Lifeline
+                  </span>{" "}
+                  (call or text 988) or go to your nearest emergency room. This
+                  form is not monitored for emergencies.
+                </p>
+              </div>
+            </div>
+
+            {/* Right — form */}
+            <form
+              onSubmit={handleSubmit}
+              className="bg-warm-cream rounded-2xl p-8 space-y-5"
+            >
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label
+                    htmlFor="first_name"
+                    className="block text-xs font-medium text-charcoal uppercase tracking-widest mb-2"
+                  >
+                    First Name
+                  </label>
+                  <input
+                    type="text"
+                    id="first_name"
+                    name="first_name"
+                    value={formData.first_name}
+                    onChange={handleChange}
+                    placeholder="Jane"
+                    className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-charcoal text-sm focus:outline-none focus:ring-2 focus:ring-sage-teal/40 bg-white"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="last_name"
+                    className="block text-xs font-medium text-charcoal uppercase tracking-widest mb-2"
+                  >
+                    Last Name
+                  </label>
+                  <input
+                    type="text"
+                    id="last_name"
+                    name="last_name"
+                    value={formData.last_name}
+                    onChange={handleChange}
+                    placeholder="Doe"
+                    className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-charcoal text-sm focus:outline-none focus:ring-2 focus:ring-sage-teal/40 bg-white"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="email"
+                  className="block text-xs font-medium text-charcoal uppercase tracking-widest mb-2"
+                >
+                  Email
+                </label>
+                <input
+                  type="email"
+                  id="email"
+                  name="email"
+                  value={formData.email}
+                  onChange={handleChange}
+                  placeholder="jane@example.com"
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-charcoal text-sm focus:outline-none focus:ring-2 focus:ring-sage-teal/40 bg-white"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="message"
+                  className="block text-xs font-medium text-charcoal uppercase tracking-widest mb-2"
+                >
+                  What brings you here?{" "}
+                  <span className="text-stone-gray normal-case">(optional)</span>
+                </label>
+                <textarea
+                  id="message"
+                  name="message"
+                  rows={5}
+                  value={formData.message}
+                  onChange={handleChange}
+                  placeholder="A brief note about what's been going on..."
+                  className="w-full px-4 py-2.5 border border-gray-200 rounded-lg text-charcoal text-sm focus:outline-none focus:ring-2 focus:ring-sage-teal/40 bg-white resize-none"
+                />
+              </div>
+
+              <button type="submit" className="btn-primary w-full text-center">
+                Send Message →
+              </button>
+            </form>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="bg-warm-cream py-16">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-bold italic text-charcoal mb-8 text-center">
+            FAQs
+          </h2>
+          <div className="space-y-4">
+            {faqs.map(({ q, a }) => (
+              <div key={q} className="bg-white rounded-xl p-6 shadow-sm">
+                <h3 className="font-semibold text-charcoal mb-3">{q}</h3>
+                <p className="text-stone-gray text-sm leading-relaxed">{a}</p>
+              </div>
+            ))}
+          </div>
+          <p className="text-center text-stone-gray text-sm mt-8">
+            — Brigit Jacoby, LCSW #121726
+          </p>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/app/contact/ContactForm.tsx
+++ b/src/app/contact/ContactForm.tsx
@@ -103,10 +103,10 @@ export default function ContactForm() {
                 <p className="text-sm text-charcoal">
                   <span className="font-medium">Phone:</span>{" "}
                   <a
-                    href="tel:4154390499"
+                    href="tel:3105611461"
                     className="text-sage-teal hover:underline"
                   >
-                    (415) 439-0499
+                    (310) 561-1461
                   </a>
                 </p>
                 <p className="text-sm text-charcoal">

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,219 +1,58 @@
-"use client";
+import type { Metadata } from "next";
+import Link from "next/link";
+import ContactForm from "./ContactForm";
 
-import React, { useState, ChangeEvent, FormEvent } from "react";
-import Navbar from "../components/Navbar";
-import Footer from "../components/Footer";
-import emailjs from "emailjs-com";
-import Image from "next/image";
-import { ToastContainer, toast } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
-
-interface FormData {
-  first_name: string;
-  last_name: string;
-  email: string;
-  message: string;
-}
+export const metadata: Metadata = {
+  title: "Book a Free Consultation | Brigit Jacoby, LCSW",
+  description:
+    "Ready to take the first step? Book a free 20-minute consultation with Brigit Jacoby, LCSW — anxiety therapist in Los Angeles and Santa Monica. No pressure, no commitment.",
+};
 
 export default function Contact() {
-  const [formData, setFormData] = useState<FormData>({
-    first_name: "",
-    last_name: "",
-    email: "",
-    message: "",
-  });
-
-  const handleChange = (
-    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ): void => {
-    const { name, value } = e.target;
-    setFormData((prevData) => ({ ...prevData, [name]: value }));
-  };
-
-  const handleSubmit = async (e: FormEvent): Promise<void> => {
-    e.preventDefault();
-
-    if (
-      !formData.first_name ||
-      !formData.last_name ||
-      !formData.email ||
-      !formData.message
-    ) {
-      toast.error("All fields are required! Please fill out all fields.");
-      return;
-    }
-
-    try {
-      const result = await emailjs.send(
-        "service_tldiyls",
-        "template_qzfrvvp",
-        { ...formData },
-        "ESJuALi_woGqpuAJe",
-      );
-
-      if (result.text === "OK") {
-        toast.success("Message sent successfully!");
-        setFormData({ first_name: "", last_name: "", email: "", message: "" });
-      } else {
-        toast.error("Message not sent. Please try again.");
-      }
-    } catch (error) {
-      console.error("EmailJS Error:", error);
-      toast.error("Failed to send the message, please try again later.");
-    }
-  };
-
   return (
-    <>
-      {/* Toast Container for displaying toast notifications */}
-      <ToastContainer />
-
-      <Navbar />
-      <div
-        className="bg-gray-100"
-        style={{
-          minHeight: "85vh",
-          background: "linear-gradient(to bottom, #E6E6E6, #F5F5F5)",
-        }}
-      >
-        <div className="container mx-auto py-20 flex flex-col md:flex-row justify-center items-center">
-          {/* Left Section - Contact Info */}
-          <div className="w-full md:w-1/3 mb-10 md:mb-0 text-center md:text-left">
-            <h1 className="text-4xl text-gray-800 font-bold mb-4">
-              Contact Us
-            </h1>
-            <p className="text-lg text-gray-700 mb-4">
-              You can reach us via email or phone:
-            </p>
-            <p className="text-lg text-gray-700">
-              <strong>Email:</strong>{" "}
-              <a
-                href="mailto:brigit@goldengatetherapy.com"
-                className="text-blue-600"
-              >
-                brigit@goldengatetherapy.com
-              </a>
-            </p>
-            <p className="text-lg text-gray-700">
-              <strong>Phone:</strong> (415) 439-0499
-            </p>
-
-            {/* Add Image Below Contact Info using Next.js Image component */}
-            <div className="mt-6">
-              <Image
-                src="/contact.png"
-                alt="Contact"
-                width={500} // Specify width
-                height={300} // Specify height
-                className="w-full h-auto rounded-lg shadow-md"
-              />
-            </div>
-          </div>
-
-          {/* Right Section - Form */}
-          <div className="w-full md:w-2/3">
-            <form
-              onSubmit={handleSubmit}
-              className="max-w-lg mx-auto bg-white shadow-md rounded-lg px-8 pt-6 pb-8"
-            >
-              {/* First Name and Last Name */}
-              <div className="flex flex-col md:flex-row mb-4">
-                <div className="w-full md:w-1/2 pr-0 md:pr-2 mb-4 md:mb-0">
-                  <label
-                    htmlFor="first_name"
-                    className="block text-gray-700 text-sm font-bold mb-2"
-                  >
-                    First Name
-                  </label>
-                  <input
-                    type="text"
-                    id="first_name"
-                    name="first_name"
-                    value={formData.first_name}
-                    onChange={handleChange}
-                    placeholder="Enter your first name"
-                    className="w-full px-3 py-2 border rounded-lg text-gray-700 focus:outline-none focus:ring focus:ring-blue-300"
-                  />
-                </div>
-                <div className="w-full md:w-1/2 pl-0 md:pl-2">
-                  <label
-                    htmlFor="last_name"
-                    className="block text-gray-700 text-sm font-bold mb-2"
-                  >
-                    Last Name
-                  </label>
-                  <input
-                    type="text"
-                    id="last_name"
-                    name="last_name"
-                    value={formData.last_name}
-                    onChange={handleChange}
-                    placeholder="Enter your last name"
-                    className="w-full px-3 py-2 border rounded-lg text-gray-700 focus:outline-none focus:ring focus:ring-blue-300"
-                  />
-                </div>
-              </div>
-
-              {/* Email */}
-              <div className="mb-4">
-                <label
-                  htmlFor="email"
-                  className="block text-gray-700 text-sm font-bold mb-2"
-                >
-                  Email
-                </label>
-                <input
-                  type="email"
-                  id="email"
-                  name="email"
-                  value={formData.email}
-                  onChange={handleChange}
-                  placeholder="Enter your email address"
-                  className="w-full px-3 py-2 border rounded-lg text-gray-700 focus:outline-none focus:ring focus:ring-blue-300"
-                />
-              </div>
-
-              {/* Message */}
-              <div className="mb-6">
-                <label
-                  htmlFor="message"
-                  className="block text-gray-700 text-sm font-bold mb-2"
-                >
-                  Message
-                </label>
-                <textarea
-                  id="message"
-                  name="message"
-                  rows={6}
-                  value={formData.message}
-                  onChange={handleChange}
-                  placeholder="Write a brief message"
-                  className="w-full px-3 py-2 border rounded-lg text-gray-700 focus:outline-none focus:ring focus:ring-blue-300"
-                ></textarea>
-              </div>
-
-              <div className="text-center">
-                <button
-                  type="submit"
-                  className="bg-blue-500 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-600 focus:outline-none focus:ring focus:ring-blue-300"
-                >
-                  Submit
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-
-        {/* Emergency Disclosure */}
-        <div className="w-full bg-gray-200 py-4 text-center text-gray-700">
-          <p className="text-sm">
-            While I am fast to respond, this is not meant to serve as an
-            emergency contact. If you are experiencing an emergency, please call
-            911 or go to your nearest emergency room.
+    <main>
+      {/* Hero */}
+      <section className="bg-warm-cream py-20 lg:py-24">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-6">
+            Free Consultation · No Commitment
           </p>
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-6">
+            Let&apos;s talk.
+          </h1>
+          <p className="text-base sm:text-lg text-stone-gray leading-relaxed max-w-2xl mx-auto mb-10">
+            Taking the first step is often the hardest part. A free 20-minute
+            consultation is a relaxed, no-pressure conversation. We&apos;ll
+            talk about what&apos;s been going on for you, how I work, and
+            whether it feels like a match.
+          </p>
+          <div className="bg-white rounded-2xl p-8 shadow-sm max-w-xl mx-auto">
+            <p className="text-sm font-semibold text-charcoal uppercase tracking-widest mb-3">
+              Book a Free Consultation
+            </p>
+            <p className="text-stone-gray text-sm leading-relaxed mb-6">
+              Schedule directly below, or send a message and I&apos;ll be in
+              touch within 1–2 business days.
+            </p>
+            <Link href="https://goldengatetherapy.clientsecure.me/request/service" className="btn-primary block text-center">
+              Schedule Now →
+            </Link>
+          </div>
         </div>
-      </div>
-      <Footer />
-    </>
+      </section>
+
+      {/* Form + FAQ */}
+      <ContactForm />
+
+      {/* Final CTA */}
+      <section className="bg-deep-teal py-16">
+        <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p className="text-white/80 text-lg leading-relaxed">
+            I look forward to connecting with you.
+          </p>
+          <p className="text-white font-semibold mt-2">— Brigit Jacoby, LCSW</p>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,19 +3,34 @@
 @tailwind utilities;
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --sage-teal: #1d9e75;
+  --deep-teal: #0f6e56;
+  --soft-sage: #e1f5ee;
+  --warm-cream: #f7f5f0;
+  --charcoal: #2c2c2a;
+  --stone-gray: #888780;
 }
 
 body {
-  color: var(--foreground);
-  background: var(--background);
+  color: var(--charcoal);
+  background: var(--warm-cream);
   font-family: Arial, Helvetica, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1,
+h2 {
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+@layer components {
+  .btn-primary {
+    @apply inline-block bg-sage-teal text-white font-medium py-3 px-7 rounded-full hover:bg-deep-teal transition-colors duration-200 text-sm tracking-wide;
+  }
+  .btn-outline {
+    @apply inline-block border border-charcoal text-charcoal font-medium py-3 px-7 rounded-full hover:bg-charcoal hover:text-white transition-colors duration-200 text-sm tracking-wide;
+  }
+  .btn-white {
+    @apply inline-block bg-white text-deep-teal font-medium py-3 px-7 rounded-full hover:bg-soft-sage transition-colors duration-200 text-sm tracking-wide;
+  }
 }

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,164 +1,275 @@
-"use client";
-
-import { useRouter } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
 import Image from "next/image";
-import Navbar from "../components/Navbar";
-import Footer from "../components/Footer";
 
-const quoteText = `“If you put your mind to it, you can accomplish anything.” - Doc Emmet Brown`;
+export const metadata: Metadata = {
+  title:
+    "Brigit Jacoby, LCSW | Anxiety Therapist in Los Angeles & Santa Monica",
+  description:
+    "Virtual therapy for high-achieving adults in Los Angeles. Specializing in anxiety, people-pleasing, and authentic relationships. Book a free 20-minute consultation.",
+};
+
+const recognitionItems = [
+  "Feel chronically anxious — even when nothing is technically wrong",
+  "Say yes automatically, then quietly resent it",
+  "Worry that people only love the version of you that has it together",
+  "Have a hard time asking for what you need without guilt",
+  "Want deeper, more honest relationships — but don't know how to let people in",
+  "Are tired of feeling like a guest in your own life",
+];
+
+const expectations = [
+  {
+    title: "Honest & Warm",
+    body: "A judgment-free space where you can show up exactly as you are — the put-together version, the exhausted one, or the one without the right words yet.",
+  },
+  {
+    title: "Evidence-Based",
+    body: "Sessions draw from CBT, Acceptance and Commitment Therapy, and attachment-based approaches — tailored to you, not cookie-cutter.",
+  },
+  {
+    title: "Fully Virtual",
+    body: "Sessions from wherever you're most comfortable — your home, your car, your office. No commute, no waiting room, just space for you.",
+  },
+];
+
+const services = [
+  {
+    title: "Anxiety & High-Functioning Stress",
+    body: "For the person who can't slow down, over-prepares for everything, and always feels like the other shoe is about to drop.",
+    href: "/services#anxiety",
+  },
+  {
+    title: "People-Pleasing & Boundaries",
+    body: "For the person who's spent years making sure everyone else is okay — at the expense of their own needs and sense of self.",
+    href: "/services#people-pleasing",
+  },
+  {
+    title: "Finding Your Authentic Voice",
+    body: "For the person who's excellent at communicating — but struggles to speak honestly about what they feel or what they need.",
+    href: "/services#voice",
+  },
+  {
+    title: "Relationships & Intimacy",
+    body: "For the person who craves deeper connection but finds that truly being known feels like a risk they're not ready to take.",
+    href: "/services#relationships",
+  },
+];
 
 export default function Home() {
-  const router = useRouter();
-  const handleClick = () => {
-    router.push("https://goldengatetherapy.clientsecure.me/request/service");
-  };
-
   return (
-    <div className="bg-gray-800">
-      <Navbar />
-      <div className="relative">
-        {/* Image Section */}
-        <div className="relative w-full h-[85vh]">
-          {/* Default Image for larger screens */}
-          <Image
-            src="/family_home.png"
-            alt="Family Home"
-            layout="fill"
-            objectFit="cover"
-            className="absolute inset-0 hidden sm:block"
-          />
-          {/* Mobile Image for smaller screens */}
-          <Image
-            src="/family_home_mobile.png"
-            alt="Family Home"
-            layout="fill"
-            objectFit="cover"
-            className="absolute inset-0 sm:hidden"
-          />
-          {/* Title and Subtitle */}
-          <div className="absolute inset-0 flex flex-col items-center justify-center bg-black bg-opacity-50 px-4">
-            <h1 className="text-3xl sm:text-4xl font-bold text-white mb-4 text-center">
-              Welcome to Golden Gate Therapy
-            </h1>
-            <p className="text-lg sm:text-xl text-white mb-8 text-center">
-              Helping you achieve balance and well-being.
-            </p>
-            <button
-              className="bg-red-600 text-white py-2 px-6 rounded hover:bg-red-700 text-sm sm:text-base"
-              onClick={handleClick}
-            >
-              Get Started
-            </button>
+    <main>
+      {/* Hero */}
+      <section className="bg-warm-cream py-20 lg:py-28">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
+            <div>
+              <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-6">
+                Anxiety Therapist · Los Angeles · Virtual Throughout California
+              </p>
+              <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-6">
+                A space to stop performing and start living.
+              </h1>
+              <p className="text-base sm:text-lg text-stone-gray leading-relaxed mb-4">
+                You&apos;ve worked hard to build a life that looks great from
+                the outside. But privately? There&apos;s a quiet, persistent hum
+                of anxiety that never quite goes away.
+              </p>
+              <p className="text-base sm:text-lg text-stone-gray leading-relaxed mb-10">
+                I help high-achieving adults in Los Angeles untangle anxiety,
+                let go of people-pleasing patterns, and find the voice
+                they&apos;ve been keeping to themselves.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Link href="/contact" className="btn-primary text-center">
+                  Book a Free Consultation →
+                </Link>
+                <Link href="/about" className="btn-outline text-center">
+                  Learn More About Working Together
+                </Link>
+              </div>
+            </div>
+            <div className="relative flex justify-center lg:justify-end">
+              <div className="relative w-full max-w-md">
+                <div className="absolute -inset-4 bg-soft-sage rounded-3xl -rotate-2" />
+                <Image
+                  src="/brigit.png"
+                  alt="Brigit Jacoby, LCSW — Anxiety therapist in Los Angeles"
+                  width={500}
+                  height={600}
+                  className="relative rounded-2xl shadow-xl object-cover w-full"
+                  priority
+                />
+              </div>
+            </div>
           </div>
         </div>
+      </section>
 
-        {/* Solutions for Sustainability Section */}
-        <div className="flex flex-col sm:flex-row justify-between items-center bg-white p-4 sm:p-6 rounded-lg shadow-md mt-8 mx-4 sm:mx-0">
-          <div className="w-full sm:w-1/2 p-4">
-            <p className="text-lg sm:text-xl text-gray-700 leading-relaxed">
-              <strong>Virtual and In-Home Services</strong> available throughout
-              California.
-            </p>
+      {/* Recognition section */}
+      <section className="bg-soft-sage py-16 lg:py-20">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-10">
+            <h2 className="text-3xl sm:text-4xl font-bold italic text-charcoal mb-4">
+              This might be the right fit if you...
+            </h2>
           </div>
-          <div className="w-full sm:w-1/2 p-4">
-            <Image
-              src="/boy_laptop.png"
-              alt="Virtual and In-Home Services"
-              width={400}
-              height={250}
-              objectFit="cover"
-            />
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {recognitionItems.map((item, i) => (
+              <div
+                key={i}
+                className="bg-white rounded-xl p-5 shadow-sm flex items-start gap-3"
+              >
+                <span className="mt-1 flex-shrink-0 w-5 h-5 rounded-full bg-sage-teal flex items-center justify-center">
+                  <svg
+                    className="w-3 h-3 text-white"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={3}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                </span>
+                <p className="text-sm text-charcoal leading-relaxed">{item}</p>
+              </div>
+            ))}
           </div>
+          <p className="text-center text-lg font-medium text-deep-teal mt-8">
+            If that sounds familiar, you&apos;re in the right place.
+          </p>
         </div>
+      </section>
 
-        {/* Routines and Stress Section */}
-        <div className="flex flex-col sm:flex-row-reverse justify-between items-center bg-gray-100 p-4 sm:p-6 rounded-lg shadow-md mt-8 mx-4 sm:mx-0">
-          <div className="w-full sm:w-1/2 p-4">
-            <p className="text-lg sm:text-xl text-gray-700 leading-relaxed">
-              <strong>Routines</strong> break, <strong>meltdowns</strong>{" "}
-              happen, and <strong>stress</strong> is induced for everyone
-              involved.
-            </p>
-          </div>
-          <div className="w-full sm:w-1/2 p-4">
-            <Image
-              src="/screaming.png"
-              alt="Routines and Stress"
-              width={400}
-              height={250}
-              objectFit="cover"
-            />
-          </div>
-        </div>
-
-        {/* Changes in Family Dynamics Section */}
-        <div className="flex flex-col sm:flex-row justify-between items-center bg-white p-4 sm:p-6 rounded-lg shadow-md mt-8 mx-4 sm:mx-0">
-          <div className="w-full sm:w-1/2 p-4">
-            <p className="text-lg sm:text-xl text-gray-700 leading-relaxed">
-              <strong>This is where I come in!</strong> Changes in family
-              dynamics are a source of information and insight into the root of
-              a problem or a potential solution.
-            </p>
-          </div>
-          <div className="w-full sm:w-1/2 p-4">
-            <Image
-              src="/family_table.png"
-              alt="Changes in Family Dynamics"
-              width={400}
-              height={250}
-              objectFit="cover"
-            />
-          </div>
-        </div>
-
-        {/* Embrace Change and Resilience Section */}
-        <div className="flex flex-col sm:flex-row-reverse justify-between items-center bg-gray-100 p-4 sm:p-6 rounded-lg shadow-md mt-8 mx-4 sm:mx-0">
-          <div className="w-full sm:w-1/2 p-4">
-            <p className="text-lg sm:text-xl text-gray-700 leading-relaxed">
-              I am here to help you <strong>embrace change</strong> as we
-              <strong> uncover resiliency</strong> all while dealing with
-              feelings of <strong>shame</strong>, <strong>discomfort</strong>,
-              and <strong>guilt</strong>.
+      {/* What to expect */}
+      <section className="bg-white py-16 lg:py-20">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-12">
+            <h2 className="text-3xl sm:text-4xl font-bold italic text-charcoal mb-4">
+              What you can expect
+            </h2>
+            <p className="text-stone-gray max-w-xl mx-auto">
+              Therapy with me is conversational, collaborative, and grounded in
+              evidence. You won&apos;t be handed a worksheet and sent on your
+              way.
             </p>
           </div>
-          <div className="w-full sm:w-1/2 p-4">
-            <Image
-              src="/counseling.png"
-              alt="Embrace Change and Resilience"
-              width={400}
-              height={250}
-              objectFit="cover"
-            />
+          <div className="grid md:grid-cols-3 gap-6">
+            {expectations.map(({ title, body }) => (
+              <div key={title} className="border border-gray-100 rounded-2xl p-6">
+                <div className="w-8 h-1 bg-sage-teal rounded mb-4" />
+                <h3 className="font-semibold text-charcoal text-lg mb-3">
+                  {title}
+                </h3>
+                <p className="text-stone-gray text-sm leading-relaxed">{body}</p>
+              </div>
+            ))}
           </div>
         </div>
+      </section>
 
-        {/* Strength-based Approach Section */}
-        <div className="flex flex-col sm:flex-row justify-between items-center bg-white p-4 sm:p-6 rounded-lg shadow-md mt-8 mx-4 sm:mx-0">
-          <div className="w-full sm:w-1/2 p-4">
-            <p className="text-lg sm:text-xl text-gray-700 leading-relaxed">
-              Using a <strong>Strength-based approach</strong>, your goals and
-              hopes for the future are much closer than you think!
+      {/* Services preview */}
+      <section className="bg-warm-cream py-16 lg:py-20">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-12">
+            <h2 className="text-3xl sm:text-4xl font-bold italic text-charcoal mb-4">
+              How I can help
+            </h2>
+            <p className="text-stone-gray max-w-xl mx-auto">
+              Individual therapy for adults throughout California via secure,
+              confidential video sessions.
             </p>
           </div>
-          <div className="w-full sm:w-1/2 p-4">
-            <Image
-              src="/strength.png"
-              alt="Strength-based Approach"
-              width={400}
-              height={250}
-              objectFit="cover"
-            />
+          <div className="grid sm:grid-cols-2 gap-5">
+            {services.map(({ title, body, href }) => (
+              <Link
+                key={title}
+                href={href}
+                className="group bg-white rounded-2xl p-6 shadow-sm hover:shadow-md transition-shadow"
+              >
+                <h3 className="font-semibold text-charcoal text-lg mb-2 group-hover:text-sage-teal transition-colors">
+                  {title}
+                </h3>
+                <p className="text-stone-gray text-sm leading-relaxed mb-4">
+                  {body}
+                </p>
+                <span className="text-sage-teal text-xs font-medium tracking-wide">
+                  Learn more →
+                </span>
+              </Link>
+            ))}
+          </div>
+          <div className="text-center mt-8">
+            <Link href="/services" className="btn-outline">
+              View All Services
+            </Link>
           </div>
         </div>
+      </section>
 
-        {/* Quote Section */}
-        <div className="bg-white p-6 rounded-lg shadow-md mt-8 mx-4 sm:mx-0">
-          <blockquote className="text-lg sm:text-2xl text-gray-900 italic font-semibold border-l-4 border-red-600 pl-4">
-            {quoteText}
-          </blockquote>
+      {/* About snippet */}
+      <section className="bg-white py-16 lg:py-20">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid lg:grid-cols-2 gap-12 items-center">
+            <div className="relative">
+              <Image
+                src="/brigit.png"
+                alt="Brigit Jacoby, Licensed Clinical Social Worker in Venice Beach"
+                width={480}
+                height={560}
+                className="rounded-2xl shadow-lg object-cover w-full"
+              />
+            </div>
+            <div>
+              <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-4">
+                About Brigit
+              </p>
+              <h2 className="text-3xl sm:text-4xl font-bold italic text-charcoal mb-5">
+                Hi, I&apos;m Brigit.
+              </h2>
+              <p className="text-stone-gray leading-relaxed mb-4">
+                I&apos;m a Licensed Clinical Social Worker based in Venice
+                Beach, and I work with high-achieving adults who are done
+                performing and ready to actually live.
+              </p>
+              <p className="text-stone-gray leading-relaxed mb-4">
+                My clients are smart, self-aware, and often their own harshest
+                critics. They come to therapy not because they&apos;re falling
+                apart, but because something quieter is happening: a growing
+                disconnection between who they are and how they&apos;re living.
+              </p>
+              <p className="text-stone-gray leading-relaxed mb-8">
+                Therapy works when you feel safe enough to be honest, so
+                that&apos;s always where we start.
+              </p>
+              <Link href="/about" className="btn-primary">
+                More About Me & My Approach →
+              </Link>
+            </div>
+          </div>
         </div>
-      </div>
-      <Footer />
-    </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="bg-deep-teal py-20">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-3xl sm:text-4xl font-bold italic text-white mb-5">
+            Ready to take the first step?
+          </h2>
+          <p className="text-white/80 text-lg leading-relaxed mb-8">
+            A free 20-minute consultation is a relaxed, no-pressure
+            conversation. We&apos;ll talk about what&apos;s been going on for
+            you, how I work, and whether it feels like a match.
+          </p>
+          <Link href="/contact" className="btn-white">
+            Book Your Free Consultation →
+          </Link>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -9,6 +9,27 @@ export const metadata: Metadata = {
     "Virtual therapy for high-achieving adults in Los Angeles. Specializing in anxiety, people-pleasing, and authentic relationships. Book a free 20-minute consultation.",
 };
 
+const testimonials = [
+  {
+    quote:
+      "After over half a year of weekly appointments with Brigit, I will say that she has helped me with my mental health. From helping me process feelings through difficult times, helping me create healthier habits, or challenging me to get out of my comfort zone. Brigit is extremely understanding and is always helping me solve my problems!",
+    attribution: "Verified client, age 25–34",
+    detail: "36 sessions · Grow Therapy",
+  },
+  {
+    quote:
+      "I thought that she seemed very easy to communicate with openly and I find that inviting feeling to be important for individuals looking for therapy. She was very intelligent, positive, and creates a safe space easily.",
+    attribution: "Verified client, age 25–34",
+    detail: "Grow Therapy",
+  },
+  {
+    quote:
+      "She was very sweet and welcoming. Brigit seemed like she really wanted to get to the base of the problem and where to go from there. She was very genuine and willing to help me work through things.",
+    attribution: "Verified client, age 18–24",
+    detail: "Grow Therapy",
+  },
+];
+
 const recognitionItems = [
   "Feel chronically anxious — even when nothing is technically wrong",
   "Say yes automatically, then quietly resent it",
@@ -250,6 +271,41 @@ export default function Home() {
                 More About Me & My Approach →
               </Link>
             </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Testimonials */}
+      <section className="bg-soft-sage py-16 lg:py-20">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-12">
+            <h2 className="text-3xl sm:text-4xl font-bold italic text-charcoal mb-3">
+              What clients say
+            </h2>
+            <p className="text-stone-gray text-sm">
+              4.9 rating · Verified reviews from Grow Therapy
+            </p>
+          </div>
+          <div className="grid md:grid-cols-3 gap-6">
+            {testimonials.map(({ quote, attribution, detail }) => (
+              <div key={attribution + detail} className="bg-white rounded-2xl p-6 shadow-sm flex flex-col">
+                {/* Stars */}
+                <div className="flex gap-0.5 mb-4">
+                  {[...Array(5)].map((_, i) => (
+                    <svg key={i} className="w-4 h-4 text-amber-400" fill="currentColor" viewBox="0 0 20 20">
+                      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                    </svg>
+                  ))}
+                </div>
+                <p className="text-charcoal text-sm leading-relaxed flex-1 mb-5">
+                  &ldquo;{quote}&rdquo;
+                </p>
+                <div>
+                  <p className="text-xs font-semibold text-charcoal">{attribution}</p>
+                  <p className="text-xs text-stone-gray">{detail}</p>
+                </div>
+              </div>
+            ))}
           </div>
         </div>
       </section>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,7 +47,7 @@ const jsonLd = {
   description:
     "Virtual therapy for high-achieving adults in California specializing in anxiety and people-pleasing.",
   url: "https://brigitjacoby.com",
-  telephone: "(415) 439-0499",
+  telephone: "(310) 561-1461",
   email: "brigit@goldengatetherapy.com",
   address: {
     "@type": "PostalAddress",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,20 +1,69 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+import Navbar from "./components/Navbar";
+import Footer from "./components/Footer";
 
 export const metadata: Metadata = {
-  title: "Golden Gate Therapy",
-  description: "Helping you achieve balance and well-being.",
+  metadataBase: new URL("https://brigitjacoby.com"),
+  title: {
+    default:
+      "Brigit Jacoby, LCSW | Anxiety Therapist in Los Angeles & Santa Monica",
+    template: "%s | Brigit Jacoby, LCSW",
+  },
+  description:
+    "Virtual therapy for high-achieving adults in Los Angeles. Specializing in anxiety, people-pleasing, and authentic relationships. Book a free 20-minute consultation.",
+  keywords: [
+    "anxiety therapist Los Angeles",
+    "therapist for high achievers",
+    "people-pleasing therapy Santa Monica",
+    "virtual therapy California",
+    "LCSW Santa Monica",
+    "therapy for anxiety Westside LA",
+    "boundaries therapist Los Angeles",
+    "high-functioning anxiety therapy",
+    "authentic relationships therapy",
+    "Brigit Jacoby LCSW",
+  ],
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: "https://brigitjacoby.com",
+    siteName: "Brigit Jacoby, LCSW",
+    title:
+      "Brigit Jacoby, LCSW | Anxiety Therapist in Los Angeles & Santa Monica",
+    description:
+      "Virtual therapy for high-achieving adults in Los Angeles. Specializing in anxiety, people-pleasing, and authentic relationships.",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "MedicalBusiness",
+  name: "Brigit Jacoby, LCSW",
+  description:
+    "Virtual therapy for high-achieving adults in California specializing in anxiety and people-pleasing.",
+  url: "https://brigitjacoby.com",
+  telephone: "(415) 439-0499",
+  email: "brigit@goldengatetherapy.com",
+  address: {
+    "@type": "PostalAddress",
+    addressLocality: "Venice Beach",
+    addressRegion: "CA",
+    addressCountry: "US",
+  },
+  areaServed: "California",
+  priceRange: "$$",
+  medicalSpecialty: "Psychiatry",
+  founder: {
+    "@type": "Person",
+    name: "Brigit Jacoby",
+    jobTitle: "Licensed Clinical Social Worker",
+    hasCredential: "LCSW #121726",
+  },
 };
 
 export default function RootLayout({
@@ -24,10 +73,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
+      <body>
+        <Navbar />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,1 @@
-import Home from "./home/page";
-
-export default function Root() {
-  return <Home />;
-}
+export { default, metadata } from "./home/page";

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: "https://brigitjacoby.com/sitemap.xml",
+  };
+}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,82 +1,172 @@
-import Image from "next/image";
-import Navbar from "../components/Navbar";
-import Footer from "../components/Footer";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title:
+    "Therapy Services | Anxiety, People-Pleasing & Boundaries | Los Angeles",
+  description:
+    "Individual therapy for high-achieving adults. Brigit Jacoby, LCSW offers virtual sessions throughout California for anxiety, people-pleasing, boundaries, and authentic relationships.",
+};
+
+const services = [
+  {
+    id: "anxiety",
+    title: "Anxiety & High-Functioning Stress",
+    subtitle: "For the person who can't seem to slow down",
+    body: "Anxiety doesn't always look like panic attacks. For high achievers, it often shows up as the inability to slow down, constant over-preparation, a nagging sense that the other shoe is about to drop, or the relentless feeling that you're not doing enough — even when you're doing everything. We'll work to understand what your anxiety is trying to protect you from, and help you build a different relationship with it.",
+    keywords: ["high-functioning anxiety therapy", "anxiety therapist Los Angeles"],
+  },
+  {
+    id: "people-pleasing",
+    title: "People-Pleasing & Boundaries",
+    subtitle: "For the person who always puts everyone else first",
+    body: "If you've spent your life making sure everyone else is okay — at the expense of your own needs, time, and sometimes sense of self — this work is for you. Together we'll explore where that pattern came from, what it's costing you, and how to start saying what you actually mean without the guilt spiral that usually follows.",
+    keywords: ["people-pleasing therapy Santa Monica", "boundaries therapist Los Angeles"],
+  },
+  {
+    id: "voice",
+    title: "Finding Your Voice & Authentic Expression",
+    subtitle: "For the person who's great at communicating but not at being heard",
+    body: "There's a difference between communicating and being heard. A lot of my clients are excellent at the first one — articulate, persuasive, professional. But speaking honestly about what they feel, what they need, or what they disagree with? That's where it gets hard. We'll work on helping you find your voice and actually use it — in your relationships, your work, and with yourself.",
+    keywords: ["authentic relationships therapy", "therapist for high achievers"],
+  },
+  {
+    id: "relationships",
+    title: "Relationships & Intimacy",
+    subtitle: "For the person who craves deeper connection but keeps people at arm's length",
+    body: "Authentic relationships require showing up as yourself — which is hard to do when you're not entirely sure who that is, or when vulnerability feels like a risk you're not willing to take. Whether you're navigating a partnership, a friendship, a family dynamic, or the longing for deeper connection, we'll work on building the kind of relationships where you can actually be known.",
+    keywords: ["virtual therapy California", "LCSW Santa Monica"],
+  },
+];
+
+const whatToExpect = [
+  "50-minute individual sessions via secure video platform",
+  "Flexible scheduling including some evening availability",
+  "Collaborative, conversational therapy — not cookie-cutter homework",
+  "Evidence-based approaches tailored to your specific goals",
+  "Long-term partnership or short-term focused work, depending on your needs",
+];
 
 export default function Services() {
   return (
-    <>
-      <Navbar />
-      <div
-        className="bg-gray-100"
-        style={{
-          minHeight: "85vh",
-          background: "linear-gradient(to bottom, #E6E6E6, #F5F5F5)",
-        }}
-      >
-        <div className="container mx-auto py-16 px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <h1 className="text-4xl font-bold text-gray-800 mb-4">Services</h1>
-          </div>
+    <main>
+      {/* Hero */}
+      <section className="bg-warm-cream py-20 lg:py-24">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-6">
+            Individual Therapy · Virtual · Throughout California
+          </p>
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-6">
+            Therapy for high-achieving adults who are ready to stop performing
+            and start living.
+          </h1>
+          <p className="text-base sm:text-lg text-stone-gray leading-relaxed max-w-2xl mx-auto">
+            I offer individual therapy for adults throughout California via
+            secure, confidential video sessions. Every client is different, and
+            your sessions will be shaped around you.
+          </p>
+        </div>
+      </section>
 
-          {/* "What to Expect" Section */}
-          <div className="bg-white p-6 rounded-lg shadow-md mb-12">
-            <h2 className="text-2xl font-semibold text-gray-800 text-center mb-4">
-              What to Expect
-            </h2>
-
-            {/* Image Section - Full Width with Responsive Support */}
-            <div className="relative w-full mb-12">
-              {/* Desktop Image */}
-              <div className="relative w-full h-[400px] hidden sm:block">
-                <Image
-                  src="/expectations.png"
-                  alt="Expectations"
-                  layout="fill"
-                  objectFit="contain"
-                  objectPosition="center"
-                />
+      {/* Services */}
+      <section className="bg-white py-16 lg:py-20">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="space-y-8">
+            {services.map(({ id, title, subtitle, body }) => (
+              <div
+                key={id}
+                id={id}
+                className="border border-gray-100 rounded-2xl p-8 scroll-mt-20"
+              >
+                <div className="w-8 h-1 bg-sage-teal rounded mb-5" />
+                <h2 className="text-2xl sm:text-3xl font-bold italic text-charcoal mb-2">
+                  {title}
+                </h2>
+                <p className="text-xs font-medium uppercase tracking-widest text-stone-gray mb-5">
+                  {subtitle}
+                </p>
+                <p className="text-stone-gray leading-relaxed">{body}</p>
               </div>
+            ))}
+          </div>
+        </div>
+      </section>
 
-              {/* Mobile Image with Zoom-Out Effect */}
-              <div className="relative w-full h-[600px] sm:hidden">
-                <Image
-                  src="/expectations_vertical.png"
-                  alt="Expectations Mobile"
-                  layout="fill"
-                  objectFit="contain"
-                  objectPosition="center"
-                />
+      {/* What to expect */}
+      <section className="bg-soft-sage py-16 lg:py-20">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid lg:grid-cols-2 gap-12">
+            <div>
+              <h2 className="text-3xl font-bold italic text-charcoal mb-6">
+                What to expect
+              </h2>
+              <ul className="space-y-4">
+                {whatToExpect.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <span className="mt-1 flex-shrink-0 w-5 h-5 rounded-full bg-white flex items-center justify-center">
+                      <svg
+                        className="w-3 h-3 text-sage-teal"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={3}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M5 13l4 4L19 7"
+                        />
+                      </svg>
+                    </span>
+                    <span className="text-charcoal text-sm leading-relaxed">
+                      {item}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <h2 className="text-3xl font-bold italic text-charcoal mb-6">
+                Investment
+              </h2>
+              <div className="bg-white rounded-2xl p-6 shadow-sm">
+                <p className="text-stone-gray leading-relaxed mb-4">
+                  I am an out-of-network provider. A superbill can be provided
+                  for potential reimbursement through your insurance&apos;s
+                  out-of-network benefits. I recommend checking with your
+                  provider before our first session.
+                </p>
+                <p className="text-stone-gray leading-relaxed mb-4">
+                  Limited sliding scale spots are available. Please reach out to
+                  ask about availability.
+                </p>
+                <p className="text-xs text-stone-gray italic">
+                  Not sure if therapy is right for you right now? That&apos;s
+                  okay — the consultation is a no-pressure conversation, not a
+                  commitment.
+                </p>
               </div>
             </div>
           </div>
-
-          {/* Psychotherapy Approaches Text Section */}
-          <div className="bg-white p-6 rounded-lg shadow-md mb-12">
-            <p className="text-lg text-gray-700 leading-relaxed whitespace-pre-line mb-4">
-              Brigit Jacoby utilizes many forms of Psychotherapy Evidence-Based
-              Practices in order to tailor treatment plans specific to each and
-              every child and/or family’s needs. In addition to home visits,
-              virtual services are available throughout California.
-            </p>
-            <p className="text-lg text-gray-700 font-bold mb-2">
-              Some of these approaches include:
-            </p>
-            {/* Unordered List */}
-            <ul className="text-lg text-gray-700 space-y-2 mb-6">
-              <li>Cognitive Behavioral Therapy (CBT)</li>
-              <li>Play-based Therapy</li>
-              <li>Acceptance and Commitment Therapy</li>
-              <li>Interpersonal Psychotherapy</li>
-              <li>Humanistic Approach</li>
-              <li>Social/Communication Skills</li>
-            </ul>
-            <blockquote className="mt-6 text-lg sm:text-2xl text-gray-900 italic font-semibold border-l-4 border-red-600 pl-4">
-              “When there is a will, there is a way.” - George Herbert
-            </blockquote>
-          </div>
         </div>
-      </div>
-      <Footer />
-    </>
+      </section>
+
+      {/* CTA */}
+      <section className="bg-deep-teal py-20">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-3xl sm:text-4xl font-bold italic text-white mb-5">
+            Ready to get started?
+          </h2>
+          <p className="text-white/80 text-lg leading-relaxed mb-8">
+            Book a free 20-minute consultation. No pressure, no commitment —
+            just a chance to see if we&apos;re a good fit.
+          </p>
+          <Link href="/contact" className="btn-white">
+            Book a Free 20-Minute Consultation →
+          </Link>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = "https://brigitjacoby.com";
+  const now = new Date();
+
+  return [
+    { url: base, lastModified: now, changeFrequency: "monthly", priority: 1.0 },
+    { url: `${base}/about`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/services`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${base}/contact`, lastModified: now, changeFrequency: "yearly", priority: 0.7 },
+  ];
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,8 +9,15 @@ export default {
   theme: {
     extend: {
       colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+        "sage-teal": "#1D9E75",
+        "deep-teal": "#0F6E56",
+        "soft-sage": "#E1F5EE",
+        "warm-cream": "#F7F5F0",
+        charcoal: "#2C2C2A",
+        "stone-gray": "#888780",
+      },
+      fontFamily: {
+        georgia: ["Georgia", "'Times New Roman'", "serif"],
       },
     },
   },


### PR DESCRIPTION
## Summary

Complete rebuild of the site pivoting from the old Golden Gate Therapy children/family practice to Brigit's current brand: high-achieving adult anxiety and people-pleasing therapy under her personal name at brigitjacoby.com.

### What changed
- **Brand identity** — New color palette (sage teal + warm cream), Georgia italic headlines, full Tailwind config with custom brand tokens
- **All 4 pages rewritten** from scratch using copy from `Brigit_Jacoby_Website_Copy.docx` and keywords from `Brigit_Jacoby_Brand_Sheet.docx`
- **Navbar** — Sticky white, Next.js Link routing, mobile hamburger, "Book a Free Consultation" CTA
- **Footer** — 3-column with Psychology Today badge, contact info, nav links
- **Home** — Split hero with Brigit's photo, recognition checklist, 3 expectation cards, 4 service preview cards, about snippet, client testimonials (3 verified Grow Therapy reviews), deep-teal CTA banner
- **About** — Full bio, who I work with, approach, credentials, CTA
- **Services** — 4 detailed service sections with anchor IDs (`#anxiety`, `#people-pleasing`, `#voice`, `#relationships`), what to expect, investment/insurance info
- **Contact** — Booking hero, contact form (EmailJS preserved), FAQs, crisis notice
- **SEO** — Per-page `metadata` exports with keyword-rich titles and descriptions, JSON-LD `MedicalBusiness` schema in layout head, `robots.ts` and `sitemap.xml` auto-generated at build time
- **`/home` → `/` redirect** — prevents duplicate content indexing
- **Contact info** — Phone updated to (310) 561-1461, email unchanged at brigit@goldengatetherapy.com

### What's NOT in this PR
- Deployment/hosting setup
- Email migration to brigitjacoby.com (Brigit has existing contacts on the old address)
- Google Business Profile update (manual, Brigit needs to do this)