### PR TITLE
fix: mobile spacing and layout improvements

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -29,14 +29,14 @@ export default function About() {
   return (
     <main>
       {/* Page hero */}
-      <section className="bg-warm-cream py-20 lg:py-28">
+      <section className="bg-warm-cream py-10 sm:py-16 lg:py-24">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
+          <div className="grid lg:grid-cols-2 gap-8 lg:gap-16 items-center">
             <div>
-              <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-6">
+              <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-4">
                 About Brigit
               </p>
-              <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-6">
+              <h1 className="text-3xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-4 sm:mb-6">
                 You don&apos;t have to perform here.
               </h1>
               <p className="text-base sm:text-lg text-stone-gray leading-relaxed mb-4">
@@ -51,9 +51,9 @@ export default function About() {
                 and with the people they love.
               </p>
             </div>
-            <div className="relative flex justify-center lg:justify-end">
-              <div className="relative w-full max-w-md">
-                <div className="absolute -inset-4 bg-soft-sage rounded-3xl rotate-2" />
+            <div className="relative flex justify-center lg:justify-end mt-8 lg:mt-0">
+              <div className="relative w-full max-w-sm sm:max-w-md">
+                <div className="absolute -inset-2 lg:-inset-4 bg-soft-sage rounded-3xl rotate-2" />
                 <Image
                   src="/brigit.png"
                   alt="Brigit Jacoby, LCSW — Licensed Clinical Social Worker in Venice Beach"
@@ -69,7 +69,7 @@ export default function About() {
       </section>
 
       {/* Who I work with */}
-      <section className="bg-white py-16 lg:py-20">
+      <section className="bg-white py-12 lg:py-16">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid lg:grid-cols-2 gap-12 items-start">
             <div>
@@ -131,7 +131,7 @@ export default function About() {
       </section>
 
       {/* Credentials */}
-      <section className="bg-warm-cream py-16 lg:py-20">
+      <section className="bg-warm-cream py-12 lg:py-16">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold italic text-charcoal mb-8 text-center">
             Credentials

--- a/src/app/contact/ContactForm.tsx
+++ b/src/app/contact/ContactForm.tsx
@@ -136,7 +136,7 @@ export default function ContactForm() {
               onSubmit={handleSubmit}
               className="bg-warm-cream rounded-2xl p-8 space-y-5"
             >
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                   <label
                     htmlFor="first_name"

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -12,12 +12,12 @@ export default function Contact() {
   return (
     <main>
       {/* Hero */}
-      <section className="bg-warm-cream py-20 lg:py-24">
+      <section className="bg-warm-cream py-10 sm:py-16 lg:py-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-6">
+          <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-4">
             Free Consultation · No Commitment
           </p>
-          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-6">
+          <h1 className="text-3xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-4 sm:mb-6">
             Let&apos;s talk.
           </h1>
           <p className="text-base sm:text-lg text-stone-gray leading-relaxed max-w-2xl mx-auto mb-10">

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -81,27 +81,27 @@ export default function Home() {
   return (
     <main>
       {/* Hero */}
-      <section className="bg-warm-cream py-20 lg:py-28">
+      <section className="bg-warm-cream py-10 sm:py-16 lg:py-24">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
+          <div className="grid lg:grid-cols-2 gap-8 lg:gap-16 items-center">
             <div>
-              <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-6">
+              <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-4">
                 Anxiety Therapist · Los Angeles · Virtual Throughout California
               </p>
-              <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-6">
+              <h1 className="text-3xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-4 sm:mb-6">
                 A space to stop performing and start living.
               </h1>
-              <p className="text-base sm:text-lg text-stone-gray leading-relaxed mb-4">
+              <p className="text-base sm:text-lg text-stone-gray leading-relaxed mb-3">
                 You&apos;ve worked hard to build a life that looks great from
                 the outside. But privately? There&apos;s a quiet, persistent hum
                 of anxiety that never quite goes away.
               </p>
-              <p className="text-base sm:text-lg text-stone-gray leading-relaxed mb-10">
+              <p className="text-base sm:text-lg text-stone-gray leading-relaxed mb-6 sm:mb-10">
                 I help high-achieving adults in Los Angeles untangle anxiety,
                 let go of people-pleasing patterns, and find the voice
                 they&apos;ve been keeping to themselves.
               </p>
-              <div className="flex flex-col sm:flex-row gap-4">
+              <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
                 <Link href="/contact" className="btn-primary text-center">
                   Book a Free Consultation →
                 </Link>
@@ -110,9 +110,9 @@ export default function Home() {
                 </Link>
               </div>
             </div>
-            <div className="relative flex justify-center lg:justify-end">
-              <div className="relative w-full max-w-md">
-                <div className="absolute -inset-4 bg-soft-sage rounded-3xl -rotate-2" />
+            <div className="relative flex justify-center lg:justify-end mt-8 lg:mt-0">
+              <div className="relative w-full max-w-sm sm:max-w-md">
+                <div className="absolute -inset-2 lg:-inset-4 bg-soft-sage rounded-3xl -rotate-2" />
                 <Image
                   src="/brigit.png"
                   alt="Brigit Jacoby, LCSW — Anxiety therapist in Los Angeles"
@@ -128,7 +128,7 @@ export default function Home() {
       </section>
 
       {/* Recognition section */}
-      <section className="bg-soft-sage py-16 lg:py-20">
+      <section className="bg-soft-sage py-12 lg:py-16">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-10">
             <h2 className="text-3xl sm:text-4xl font-bold italic text-charcoal mb-4">
@@ -167,7 +167,7 @@ export default function Home() {
       </section>
 
       {/* What to expect */}
-      <section className="bg-white py-16 lg:py-20">
+      <section className="bg-white py-12 lg:py-16">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl sm:text-4xl font-bold italic text-charcoal mb-4">
@@ -194,7 +194,7 @@ export default function Home() {
       </section>
 
       {/* Services preview */}
-      <section className="bg-warm-cream py-16 lg:py-20">
+      <section className="bg-warm-cream py-12 lg:py-16">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl sm:text-4xl font-bold italic text-charcoal mb-4">
@@ -233,10 +233,10 @@ export default function Home() {
       </section>
 
       {/* About snippet */}
-      <section className="bg-white py-16 lg:py-20">
+      <section className="bg-white py-12 lg:py-16">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid lg:grid-cols-2 gap-12 items-center">
-            <div className="relative">
+          <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 items-center">
+            <div className="hidden lg:block relative">
               <Image
                 src="/brigit.png"
                 alt="Brigit Jacoby, Licensed Clinical Social Worker in Venice Beach"
@@ -276,7 +276,7 @@ export default function Home() {
       </section>
 
       {/* Testimonials */}
-      <section className="bg-soft-sage py-16 lg:py-20">
+      <section className="bg-soft-sage py-12 lg:py-16">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl sm:text-4xl font-bold italic text-charcoal mb-3">

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -51,12 +51,12 @@ export default function Services() {
   return (
     <main>
       {/* Hero */}
-      <section className="bg-warm-cream py-20 lg:py-24">
+      <section className="bg-warm-cream py-10 sm:py-16 lg:py-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-6">
+          <p className="text-xs font-medium tracking-widest text-sage-teal uppercase mb-4">
             Individual Therapy · Virtual · Throughout California
           </p>
-          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-6">
+          <h1 className="text-3xl sm:text-5xl lg:text-6xl font-bold italic text-charcoal leading-tight mb-4 sm:mb-6">
             Therapy for high-achieving adults who are ready to stop performing
             and start living.
           </h1>


### PR DESCRIPTION
Fixes mobile UX issues noticed after the initial launch.

- Reduce hero padding on all pages (`py-10 sm:py-16 lg:py-24` instead of `py-20`) — eliminates the large gap under the navbar on mobile
- Scale down H1 to `text-3xl` on mobile (was `text-4xl`, too large)
- Fix decorative photo background overflow — was `-inset-4` causing horizontal scroll on small screens, now `-inset-2 lg:-inset-4`
- Hide duplicate Brigit photo in about snippet on mobile (already appears in hero on that page)
- Contact form name fields stack to single column on small phones
- Reduce interior section padding site-wide for better mobile density